### PR TITLE
fix: use passed profile credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,38 +4,1390 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@aws-sdk/credential-provider-ini": {
-      "version": "0.1.0-preview.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-0.1.0-preview.1.tgz",
-      "integrity": "sha512-tumMpxYiL7HIlGV4r0lYIGirLxtMaSi3MWsy7woCsV5VJ4iw665Ci8OAHZEicUrKMUH4mEYzwxcPwef3d2k0mg==",
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
       "requires": {
-        "@aws-sdk/property-provider": "^0.1.0-preview.1",
-        "@aws-sdk/shared-ini-file-loader": "^0.1.0-preview.1",
-        "@aws-sdk/types": "^0.1.0-preview.1",
-        "tslib": "^1.8.0"
+        "tslib": "^1.11.1"
       }
     },
-    "@aws-sdk/property-provider": {
-      "version": "0.1.0-preview.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-0.1.0-preview.1.tgz",
-      "integrity": "sha512-vEN4rqhOqw9XHaFNtwSG+Zqw8r8DGeqhDICqdwZk+NJKyP1+01UpZCMhCJw62kWmQwqfYqMYKVx7yENeDwT2ew==",
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
       "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.1",
-        "tslib": "^1.8.0"
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        }
       }
     },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "0.1.0-preview.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-0.1.0-preview.1.tgz",
-      "integrity": "sha512-iPglaZZt2uhRpBO0oXww+oK9mtJQvh91o1NuuIOGMBceSou9qzMtGC5NzJzGnooodfwzARx1rgv9myJpcK38Sw==",
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
       "requires": {
-        "tslib": "^1.8.0"
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        }
       }
     },
-    "@aws-sdk/types": {
-      "version": "0.1.0-preview.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-0.1.0-preview.1.tgz",
-      "integrity": "sha512-CcZpxyN2G0I7+Jyj0om3LafYX7d30JWJAAQ+53Ysjau7jyL/xLMMkLZgniQPV8BMV7uKLXyf4hwu8JSs0Ejb+w=="
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.54.1.tgz",
+      "integrity": "sha512-yYrZ4iFZzxxx6w14WbSCL157lkoFuSfLroCswb9fV9oVfEoHRL3a4MV/7SkbK3e3LtHiJ33tLFO15kmMYIEnLA==",
+      "requires": {
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/client-cognito-identity": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.54.1.tgz",
+      "integrity": "sha512-FnEQVHAvkW0RZAYfcRv/NKANaz/5VZ6zcj07J0WCUGYizdEnp6EdiWCap69wO3H+HQeM0TAU4r2Ia772Q76sWg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.54.1",
+        "@aws-sdk/config-resolver": "3.54.1",
+        "@aws-sdk/credential-provider-node": "3.54.1",
+        "@aws-sdk/fetch-http-handler": "3.54.1",
+        "@aws-sdk/hash-node": "3.54.1",
+        "@aws-sdk/invalid-dependency": "3.54.1",
+        "@aws-sdk/middleware-content-length": "3.54.1",
+        "@aws-sdk/middleware-host-header": "3.54.1",
+        "@aws-sdk/middleware-logger": "3.54.1",
+        "@aws-sdk/middleware-retry": "3.54.1",
+        "@aws-sdk/middleware-serde": "3.54.1",
+        "@aws-sdk/middleware-signing": "3.54.1",
+        "@aws-sdk/middleware-stack": "3.54.1",
+        "@aws-sdk/middleware-user-agent": "3.54.1",
+        "@aws-sdk/node-config-provider": "3.54.1",
+        "@aws-sdk/node-http-handler": "3.54.1",
+        "@aws-sdk/protocol-http": "3.54.1",
+        "@aws-sdk/smithy-client": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "@aws-sdk/url-parser": "3.54.1",
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "@aws-sdk/util-base64-node": "3.52.0",
+        "@aws-sdk/util-body-length-browser": "3.54.0",
+        "@aws-sdk/util-body-length-node": "3.54.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.54.1",
+        "@aws-sdk/util-defaults-mode-node": "3.54.1",
+        "@aws-sdk/util-user-agent-browser": "3.54.1",
+        "@aws-sdk/util-user-agent-node": "3.54.1",
+        "@aws-sdk/util-utf8-browser": "3.52.0",
+        "@aws-sdk/util-utf8-node": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.54.1.tgz",
+      "integrity": "sha512-Ir6XG8EzbfUVqr97rkEMW7eFGByiKQGv1Oc7Nxl3BqSXYD35rP2IJ/HI5TXx+CgOY+Ov+bI3g5BZZvSCXd3OBg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.54.1",
+        "@aws-sdk/fetch-http-handler": "3.54.1",
+        "@aws-sdk/hash-node": "3.54.1",
+        "@aws-sdk/invalid-dependency": "3.54.1",
+        "@aws-sdk/middleware-content-length": "3.54.1",
+        "@aws-sdk/middleware-host-header": "3.54.1",
+        "@aws-sdk/middleware-logger": "3.54.1",
+        "@aws-sdk/middleware-retry": "3.54.1",
+        "@aws-sdk/middleware-serde": "3.54.1",
+        "@aws-sdk/middleware-stack": "3.54.1",
+        "@aws-sdk/middleware-user-agent": "3.54.1",
+        "@aws-sdk/node-config-provider": "3.54.1",
+        "@aws-sdk/node-http-handler": "3.54.1",
+        "@aws-sdk/protocol-http": "3.54.1",
+        "@aws-sdk/smithy-client": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "@aws-sdk/url-parser": "3.54.1",
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "@aws-sdk/util-base64-node": "3.52.0",
+        "@aws-sdk/util-body-length-browser": "3.54.0",
+        "@aws-sdk/util-body-length-node": "3.54.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.54.1",
+        "@aws-sdk/util-defaults-mode-node": "3.54.1",
+        "@aws-sdk/util-user-agent-browser": "3.54.1",
+        "@aws-sdk/util-user-agent-node": "3.54.1",
+        "@aws-sdk/util-utf8-browser": "3.52.0",
+        "@aws-sdk/util-utf8-node": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.54.1.tgz",
+      "integrity": "sha512-1wgOvyyQcrNeeNWX2aerLOFb2+wkHeo9kjyErUJv7NLRzQGlFXmljfNme2ydvyUMA8NCwjEjePSfmktjnGP9BA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.54.1",
+        "@aws-sdk/credential-provider-node": "3.54.1",
+        "@aws-sdk/fetch-http-handler": "3.54.1",
+        "@aws-sdk/hash-node": "3.54.1",
+        "@aws-sdk/invalid-dependency": "3.54.1",
+        "@aws-sdk/middleware-content-length": "3.54.1",
+        "@aws-sdk/middleware-host-header": "3.54.1",
+        "@aws-sdk/middleware-logger": "3.54.1",
+        "@aws-sdk/middleware-retry": "3.54.1",
+        "@aws-sdk/middleware-sdk-sts": "3.54.1",
+        "@aws-sdk/middleware-serde": "3.54.1",
+        "@aws-sdk/middleware-signing": "3.54.1",
+        "@aws-sdk/middleware-stack": "3.54.1",
+        "@aws-sdk/middleware-user-agent": "3.54.1",
+        "@aws-sdk/node-config-provider": "3.54.1",
+        "@aws-sdk/node-http-handler": "3.54.1",
+        "@aws-sdk/protocol-http": "3.54.1",
+        "@aws-sdk/smithy-client": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "@aws-sdk/url-parser": "3.54.1",
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "@aws-sdk/util-base64-node": "3.52.0",
+        "@aws-sdk/util-body-length-browser": "3.54.0",
+        "@aws-sdk/util-body-length-node": "3.54.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.54.1",
+        "@aws-sdk/util-defaults-mode-node": "3.54.1",
+        "@aws-sdk/util-user-agent-browser": "3.54.1",
+        "@aws-sdk/util-user-agent-node": "3.54.1",
+        "@aws-sdk/util-utf8-browser": "3.52.0",
+        "@aws-sdk/util-utf8-node": "3.52.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.54.1.tgz",
+      "integrity": "sha512-MPaahgP+WGdZDfvsrjiOcpdyIIt4XaT2d62x0DYhkeWR7q6/g5d73ynS9377AwVp+6LyjzisqX1lSjfUkG2ryQ==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "@aws-sdk/util-config-provider": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.54.1.tgz",
+      "integrity": "sha512-7bUCFaqXYLuH39UyBQBctAE5evRJ64eq+gpvJrJfA52ebucicy8eSF3awJ5Xk/a/ZA24vFqdv8o+SDJJme1rmg==",
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.54.1",
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.54.1.tgz",
+      "integrity": "sha512-+4ik84tPG6st6DxwymiJ/kO8OJPNjv0fROH4+OupvYiVyBLrvqoivbtwsee9mcQJ3KLkcASdht7bw271sP9wng==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.54.1.tgz",
+      "integrity": "sha512-IIJ9Or9HAxdOzhXMEB1OBUc1EXLiNPd1BD30u5mEpyaO4jJf0AKNNg7Lkhnl5yDX0oY8pbaakDFVomqGt2c9aQ==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.54.1",
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "@aws-sdk/url-parser": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.54.1.tgz",
+      "integrity": "sha512-J6/IjyniCYYJ+Y0cXvuZUB4yIKVOZvwziFwAA/mphtJEyiSjM7cOp3tATCrcBZuZn0OSRAeQlJ6xAy9MbKSHSQ==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.54.1",
+        "@aws-sdk/credential-provider-imds": "3.54.1",
+        "@aws-sdk/credential-provider-ini": "3.54.1",
+        "@aws-sdk/credential-provider-process": "3.54.1",
+        "@aws-sdk/credential-provider-sso": "3.54.1",
+        "@aws-sdk/credential-provider-web-identity": "3.54.1",
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/shared-ini-file-loader": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.54.1.tgz",
+          "integrity": "sha512-sdLJbNbBJPz4icb4OsbIMtKm2jZqeASBUYBYZfsiNP8E50EZkBOkQuKNzQikzbUZmJN+/U/3YqfrK6NzyzCd3g==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.54.1",
+            "@aws-sdk/credential-provider-imds": "3.54.1",
+            "@aws-sdk/credential-provider-sso": "3.54.1",
+            "@aws-sdk/credential-provider-web-identity": "3.54.1",
+            "@aws-sdk/property-provider": "3.54.1",
+            "@aws-sdk/shared-ini-file-loader": "3.54.1",
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.54.1.tgz",
+          "integrity": "sha512-Vdb75cv9p7dlBAHFD5LdNW9UhAmTdGTsc4RoJNM2vB08WruPJQkQJgE00/f2o1L7B53mvrH+EHbfJXu5l12jWQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.54.1.tgz",
+      "integrity": "sha512-LeRHa3mCyMsWuRpNeDGLg3KvqqM0hAw1qPszyG5F43x9EhmVCpHPepnf6TrMAbTxpbdhsy4y0+kNLTFxV3LMsw==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/shared-ini-file-loader": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.54.1.tgz",
+          "integrity": "sha512-Vdb75cv9p7dlBAHFD5LdNW9UhAmTdGTsc4RoJNM2vB08WruPJQkQJgE00/f2o1L7B53mvrH+EHbfJXu5l12jWQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.54.1.tgz",
+      "integrity": "sha512-T6fImSfKabjhAk/kgqAhYoDFmV6kRI6PDFEQg9JJ50I61wLqgWIKWQJb0nphNpgGnEVSCp+I9alrahTNXDRQsw==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.54.1",
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/shared-ini-file-loader": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.54.1.tgz",
+          "integrity": "sha512-Vdb75cv9p7dlBAHFD5LdNW9UhAmTdGTsc4RoJNM2vB08WruPJQkQJgE00/f2o1L7B53mvrH+EHbfJXu5l12jWQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.54.1.tgz",
+      "integrity": "sha512-wCOK6sK+zS89OetMz8qThqRtgu43dJgpkY7bYjVWlpfnsFGN7aqrNN/N93yhtY/YZmtD/sZVXXgTO2qDkkwl2g==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/credential-providers": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.54.1.tgz",
+      "integrity": "sha512-63lY2p4wZix+CTc8tZIOLbtqWFpMqMQ3KQzSfIVjXIxt1Qv7L0F4IjpsC0nikJTuQ3MYbjnaE22R0EAvLA7kVA==",
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.54.1",
+        "@aws-sdk/client-sso": "3.54.1",
+        "@aws-sdk/client-sts": "3.54.1",
+        "@aws-sdk/credential-provider-cognito-identity": "3.54.1",
+        "@aws-sdk/credential-provider-env": "3.54.1",
+        "@aws-sdk/credential-provider-imds": "3.54.1",
+        "@aws-sdk/credential-provider-ini": "3.54.1",
+        "@aws-sdk/credential-provider-process": "3.54.1",
+        "@aws-sdk/credential-provider-sso": "3.54.1",
+        "@aws-sdk/credential-provider-web-identity": "3.54.1",
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/shared-ini-file-loader": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.54.1.tgz",
+          "integrity": "sha512-sdLJbNbBJPz4icb4OsbIMtKm2jZqeASBUYBYZfsiNP8E50EZkBOkQuKNzQikzbUZmJN+/U/3YqfrK6NzyzCd3g==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.54.1",
+            "@aws-sdk/credential-provider-imds": "3.54.1",
+            "@aws-sdk/credential-provider-sso": "3.54.1",
+            "@aws-sdk/credential-provider-web-identity": "3.54.1",
+            "@aws-sdk/property-provider": "3.54.1",
+            "@aws-sdk/shared-ini-file-loader": "3.54.1",
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.54.1.tgz",
+          "integrity": "sha512-Vdb75cv9p7dlBAHFD5LdNW9UhAmTdGTsc4RoJNM2vB08WruPJQkQJgE00/f2o1L7B53mvrH+EHbfJXu5l12jWQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.54.1.tgz",
+      "integrity": "sha512-i2sTy8NjFXMtdlaslGS0vKbz1+9J8Nnt1A7A1gWsJmi6cXofv86glKTtxXxr1BsZu82QAZbSO4lm/XAd5gcWuQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.54.1",
+        "@aws-sdk/querystring-builder": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.54.1.tgz",
+      "integrity": "sha512-Vpu94h4vla92xLqmAZXHjSF/dw9Myf3Gd4LJMPK7Gb5XZVZgpIijqOF/vlx0YKRunuEopLlT9OFkDVBZtqtTIw==",
+      "requires": {
+        "@aws-sdk/types": "3.54.1",
+        "@aws-sdk/util-buffer-from": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.54.1.tgz",
+      "integrity": "sha512-nn+zqJ+nlO5yCxtvykLhj03e2+5wbb4fAgG47PHGCB8zjqvYDlv8jW1sryjR69dsMdylnanUmDvyvJUlQKj3eQ==",
+      "requires": {
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
+      "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.54.1.tgz",
+      "integrity": "sha512-mnp9GmIDQCtw1XtfnFyBvGLUPD0CGZx1terCoUIWVN+sd8ACpCuDM6wv9TNTU+rxcKkWiOFmNl4becSm46YXOw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.54.1.tgz",
+      "integrity": "sha512-x3RpdcCGu4bvvq5DrluBDCYyOCczcbVCjZm/GBwXy7qddu//1EBtZpJCcJ96ptp1ibjNW48jJPLftel7SK4qAg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.54.1.tgz",
+      "integrity": "sha512-Cc7CDFVTAFXjZDNYGduZMWU0F/M5uEeB/GJJGNia3QEMpGjznX7sQH/wbPyVGwcV2/ONSS6NIxhUMnFrb/yl3w==",
+      "requires": {
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.54.1.tgz",
+      "integrity": "sha512-NwF4YU+8qnfD2mimVvlrqPeDUGYRSeoG8eONzC4SajsTRe9oWprRpWgpO47b0P5xrzJRYu18Li6jNz6qR4q4mw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.54.1",
+        "@aws-sdk/service-error-classification": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.54.1.tgz",
+      "integrity": "sha512-r4weIvX7YZ62Ag9h+txQDfeK6MlFwZq7YeTYeGN57FF3sPlvMzFvI1BQ+H3A7KlQoXalAL2BzI9GPTkmTEcklg==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.54.1",
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/protocol-http": "3.54.1",
+        "@aws-sdk/signature-v4": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.54.1.tgz",
+      "integrity": "sha512-mOAa54Jwo5pG+Xs5z3VjIi4PMQVRvhsfONTlZV/GRYbJniKVE2/zLZzHLXpeChrdZjHX+kOY/1LSVpypbziu/Q==",
+      "requires": {
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.54.1.tgz",
+      "integrity": "sha512-orM7cXa14mLmsJXzJrls6iJz5nmICMvx5FP1e0q28TnIgyoqUILcndGzYm3q0l2fwk7BJdw87q6sSy56LWJPkQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/protocol-http": "3.54.1",
+        "@aws-sdk/signature-v4": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.54.1.tgz",
+      "integrity": "sha512-fh9/jzqR181M+53m0lFHf8HvCKrq6Odu+rzFenumnUjAFaFb7368/XjipqFMxfvW0XjbdGJ4UyPds2wcnqh+8Q==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.54.1.tgz",
+      "integrity": "sha512-EXHLYVzUmw6cRc3M+cz3HzDIH9R/5P6kWuaf0762CiG/kDtLr9ya4k3RbBSLAzR4wxuI58U7/DkA6mG5Dne5oA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.54.1.tgz",
+      "integrity": "sha512-Av9Ucybx4NpfLKAVpfBpH0OYWiJ7Da1RYPWyZ9YTKNGTxSUUuS448ZZ0OcP8QDaiHQV40dXGTJz0LV+WfChH8g==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/shared-ini-file-loader": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.54.1.tgz",
+          "integrity": "sha512-Vdb75cv9p7dlBAHFD5LdNW9UhAmTdGTsc4RoJNM2vB08WruPJQkQJgE00/f2o1L7B53mvrH+EHbfJXu5l12jWQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.54.1.tgz",
+      "integrity": "sha512-zY9dIIZXms4WcmpcKJxxBPqPydvUTJA3JAoqpf9Huau/oJ4VHYmQCJ6gohmHq2y2f+H0GOf74/QyngncTrKPwg==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.54.1",
+        "@aws-sdk/protocol-http": "3.54.1",
+        "@aws-sdk/querystring-builder": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.54.1.tgz",
+      "integrity": "sha512-2fA8sbFechayTemXogFU3vlllNWYpAI4vE9d3JsIhND2BQHXjv6qrkx9rXWtnALzQbX25D4Rq6Kctu/7hG1jLw==",
+      "requires": {
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.54.1.tgz",
+      "integrity": "sha512-8E4qFyKc4JaZZ+Vg7vV7OZx7DoKqNUakVX9/eZn6W3Hu7rrMcYY3M8mHZggP8z+fosRhib7xOcyh483LMZNfvA==",
+      "requires": {
+        "@aws-sdk/types": "3.54.1",
+        "@aws-sdk/util-uri-escape": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.54.1.tgz",
+      "integrity": "sha512-oqnaGov6PdgS/1lNgkif6EucySMOUAKoNCsABBPItMWAoNmWiDxKIKBlk6xX5s17teP52L/iXAASD/pqeaDmUw==",
+      "requires": {
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.54.1.tgz",
+      "integrity": "sha512-cOofY2SFZEoPbuoH4I9ZiTMf8bgUz3OOZjLtU/Qv0Efhf7NhNEwsJkG2jgSYac3UkK7tWyz1Jo1Exog+sY7hOQ=="
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.54.1.tgz",
+      "integrity": "sha512-byBH4ovK3BqVxmsWWlZOug2nfWE2t1Hw1r9B4Cn0kIftpHfy3axVBLTQ8czu5b8mbVyq8PnOKPTZ1X6Tzm/LnQ==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.52.0",
+        "@aws-sdk/types": "3.54.1",
+        "@aws-sdk/util-hex-encoding": "3.52.0",
+        "@aws-sdk/util-uri-escape": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.54.1.tgz",
+      "integrity": "sha512-OabAnQQLjhdEMafq4KdptxnmvYXz0fNRZQRU/R4M9PmO5KOO9yep+y8R259hME2uV6FtMTBms1qctN9qaryhug==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.54.1.tgz",
+      "integrity": "sha512-F0d5UokYgbv80CjZtILZ8y4hWPKwh1sk96hOTi07TBFcx6E5dS5Vi1Wm4GsRi4C8D8FeQ5dhw/XBdqCM3+tloQ==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.52.0.tgz",
+      "integrity": "sha512-xjv/cQ4goWXAiGEC/AIL/GtlHg4p4RkQKs6/zxn9jOxo1OnbppLMJ0LjCtv4/JVYIVGHrx0VJ8Exyod7Ln+NeA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.52.0.tgz",
+      "integrity": "sha512-V96YIXBuIiVu7Zk72Y9dly7Io9cYOT30Hjf77KAkBeizlFgT5gWklWYGcytPY8FxLuEy4dPLeHRmgwQnlDwgPA==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.54.0.tgz",
+      "integrity": "sha512-hnY9cXbKWJ2Fjb4bK35sFdD4vK+sFe59JtxxI336yYzANulc462LU/J1RgONXYBW60d9iwJ7U+S+9oTJrEH6WQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.54.0.tgz",
+      "integrity": "sha512-BBQB3kqHqHQp2GAINJGuse9JBM7hfU0tMp9rfw0nym4C/VRooiJVrIb28tKseLtd7nihXvsZXPvEc2jQBe1Thg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.52.0.tgz",
+      "integrity": "sha512-hsG0lMlHjJUFoXIy59QLn6x4QU/vp/e0t3EjdD0t8aymB9iuJ43UeLjYTZdrOgtbWb8MXEF747vwg+P6n+4Lxw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
+      "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.54.1.tgz",
+      "integrity": "sha512-914CZu8bGQsl3GV5QEzSOsvIadaMtoRZgFRa5XBPcA1yxdUZh7ZIf0cBBwGSKF2tI8Wupcq1WekJsTbVB+9hfg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.54.1.tgz",
+      "integrity": "sha512-PhG9kevfNOBMqiRBWeFt0B2eeou5xmEr/f5JOVg7rNE8INXwJgRilpjG5f3uDYD25tAVUipLzOeGBx4ay0Y/Gw==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.54.1",
+        "@aws-sdk/credential-provider-imds": "3.54.1",
+        "@aws-sdk/node-config-provider": "3.54.1",
+        "@aws-sdk/property-provider": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
+          "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+          "requires": {
+            "@aws-sdk/types": "3.54.1",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
+      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.52.0.tgz",
+      "integrity": "sha512-l10U2cLko6070A9DYLJG4NMtwYH8JBG2J/E+RH8uY3lad2o6fGEIkJU0jQbWbUeHYLG3IWuCxT47V4gxYrFj7g==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
+      "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.54.1.tgz",
+      "integrity": "sha512-T2ZKGurRIZ4te91JBu95L/hhSm9HwPoFT4c0fhHAiwxgdB3AugDsRePOmGHrZxFEQm9j78Nh3Wh52v8QrAR1QQ==",
+      "requires": {
+        "@aws-sdk/types": "3.54.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.54.1.tgz",
+      "integrity": "sha512-C9FYcV8Sqm1tGddphvi2A50oWyD7eeC/4E6VhPM53/XFYLKVCLOmZkSE2VCHFkmt4GCuyIruADDy4GY/eQ2eLw==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.54.1",
+        "@aws-sdk/types": "3.54.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.54.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+          "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.52.0.tgz",
+      "integrity": "sha512-LuOMa9ajWu5fQuYkmvTlQZfHaITkSle+tM/vhbU4JquRN44VUKACjRGT7UEhoU3lCL1BD0JFGMQGHI+5Mmuwfg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.52.0.tgz",
+      "integrity": "sha512-fujr7zeobZ2y5nnOnQZrCPPc+lCAhtNF/LEVslsQfd+AQ0bYWiosrKNetodQVWlfh10E2+i6/5g+1SBJ5kjsLw==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
     },
     "@babel/code-frame": {
       "version": "7.8.3",
@@ -936,14 +2288,14 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.669.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.669.0.tgz",
-      "integrity": "sha512-kuVcSRpDzvkgmeSmMX6Q32eTOb8UeihhUdavMrvUOP6fzSU19cNWS9HAIkYOi/jrEDK85cCZxXjxqE3JGZIGcw==",
+      "version": "2.1096.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1096.0.tgz",
+      "integrity": "sha512-q+hotU57U8bGpz1pf5CkO4z630ay0xGJ9HedahKPZ0Xk3/X0GH+QFYPBWJ5IMTtO30bjfPH0zTaL2vJmMXLBrQ==",
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -1093,9 +2445,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -1105,6 +2457,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1141,9 +2498,9 @@
       }
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -1564,6 +2921,11 @@
         "once": "^1.4.0"
       }
     },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1825,6 +3187,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -2883,9 +4250,9 @@
       }
     },
     "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roundtables/preamp",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Generate aws-exports in your CICD for your AWS Amplify SDK Client",
   "main": "src/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
   },
   "homepage": "https://github.com/roundtables/preamp#readme",
   "dependencies": {
-    "@aws-sdk/credential-provider-ini": "^0.1.0-preview.1",
-    "aws-sdk": "^2.669.0",
+    "@aws-sdk/client-sts": "^3.54.1",
+    "@aws-sdk/credential-providers": "^3.54.1",
+    "aws-sdk": "^2.1096.0",
     "cosmiconfig": "^6.0.0",
     "docopt": "^0.6.2",
     "esm": "^3.2.25"

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,7 +15,7 @@ async function cli(args) {
     preamp -h | --help | --version
   `
 
-  const cliargs = docopt(clidoc, { version: '2.0.1' })
+  const cliargs = docopt(clidoc, { version: '2.0.2' })
 
   const getJSON = (sourceFile) => {
     if (!!sourceFile) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,7 +11,7 @@ import { extractSourceKeys } from './extract-source'
 async function cli(args) {
   const clidoc = `
   Usage:
-    preamp [--cloud-formation-to-import=<preamp.config.js>] [--output=<aws-exports.js>]
+    preamp [--profile=<profile>] [--cloud-formation-to-import=<preamp.config.js>] [--output=<aws-exports.js>]
     preamp -h | --help | --version
   `
 
@@ -34,9 +34,10 @@ async function cli(args) {
   
   const preampConfig = defaults.config || {}
   const preampSource = defaults.fields || {}
+  const awsProfile = cliargs['--profile'] || preampConfig.profile || null
   const targetFile = cliargs['--output'] || preampConfig.output || path.resolve(process.cwd(), 'aws-exports.js')
 
-  const cfSDK = await createCloudFormationSDK()
+  const cfSDK = await createCloudFormationSDK(awsProfile)
   const { exportable, cloudFormationKeys } = extractSourceKeys(preampSource)
   const allExports = await mergeCloudFormationExports(cfSDK, cloudFormationKeys, exportable)  
   try {

--- a/src/create-cloud-formation-sdk.js
+++ b/src/create-cloud-formation-sdk.js
@@ -9,16 +9,13 @@ const createCloudFormationSDK = async (passedProfile) => {
 
         if (passedProfile) {
             try {
-
                 const stsClient = new STSClient({
                     credentials: fromSSO({
                       profile: passedProfile,
                     }),
                     region: process.env.AWS_REGION,
                   });
-              
                 const credentials = await stsClient.config.credentials();    
-
                 AWS.config.update({ credentials })
             } catch (e) {
                 console.error('Could not use profile', passedProfile)

--- a/src/create-cloud-formation-sdk.js
+++ b/src/create-cloud-formation-sdk.js
@@ -1,17 +1,35 @@
-import AWS, { EnvironmentCredentials } from 'aws-sdk'
+import AWS, { SsoCredentials, EnvironmentCredentials } from 'aws-sdk'
+import { STSClient } from '@aws-sdk/client-sts';
+import { fromSSO } from '@aws-sdk/credential-providers';
 
-const createCloudFormationSDK = async () => {
+const createCloudFormationSDK = async (passedProfile) => {
     if (!process.env.AWS_ACCESS_KEY_ID 
-        && !process.env.AWS_SECRET_ACCESS_KEY) {
+        && !process.env.AWS_SECRET_ACCESS_KEY
+        && !process.env.AWS_SESSION_TOKEN) {
 
-        console.error('AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables must be set')
-        process.exit(1)
+        if (passedProfile) {
+            try {
+
+                const stsClient = new STSClient({
+                    credentials: fromSSO({
+                      profile: passedProfile,
+                    }),
+                    region: process.env.AWS_REGION,
+                  });
+              
+                const credentials = await stsClient.config.credentials();    
+
+                AWS.config.update({ credentials })
+            } catch (e) {
+                console.error('Could not use profile', passedProfile)
+                process.exit(1)
+            }            
+        }
     }
 
     try {
         return new AWS.CloudFormation({
             apiVersion: '2010-05-15',
-            credentials: new EnvironmentCredentials('AWS')
         })
     } catch (e) {
         console.error('Could not create cloud formation SDK')


### PR DESCRIPTION
Reverts part of https://github.com/roundtables/preamp/commit/ec9fcddb70d5dfb918b3a2df619f7de8ef68580b and adds fix to use profile.

You can now use AWS SSO with this tool